### PR TITLE
Use esperanto analyzer API hosted at Heroku by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,17 @@ $ git clone https://github.com/fidelisrafael/esperanto-analyzer-react
 $ cd esperanto-analyzer-react
 $ yarn install
 $ yarn start
-``` 
+```
 
 The application will run at `http://localhost:3000`
 
-**OBS**: If you're not hosting the Python WEB API at port `5000` you will probably want to use the
-Heroku hosted API, for this update `src/Config.js` and set `developmentConfig` as follow:
+**OBS**: By default for developing environment the Web API is hosted at Heroku.
+If you'd like to use a local Web API, you have to change `developmentConfig` at `src/Config.js` file as follow:
 
 ```js
 const developmentConfig = {
-  api_host: 'esperanto-analyzer-api.herokuapp.com',
-  api_protocol: 'https'
+  api_host: '127.0.0.1:5000',
+  api_protocol: 'http'
 }
 ```
 

--- a/src/Components/SentenceAnalyzer/SentenceAnalyzeResult.jsx
+++ b/src/Components/SentenceAnalyzer/SentenceAnalyzeResult.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import Button from '@atlaskit/button';
 import EditFilledIcon from '@atlaskit/icon/glyph/edit-filled';
-import TestUtils from '../../Lib/TestUtils'
 import { InlineWord } from './Word'
 
 export const STYLES = {

--- a/src/Config.js
+++ b/src/Config.js
@@ -3,7 +3,6 @@ const defaultConfig = {
   api_protocol: 'http'
 }
 
-const developmentConfig = {...defaultConfig}
 const testConfig = {...defaultConfig}
 
 const productionConfig = {
@@ -11,8 +10,10 @@ const productionConfig = {
   api_protocol: 'https'
 }
 
+const developmentConfig = {...productionConfig}
+
 export default {
-  development: productionConfig,
+  development: developmentConfig,
   production: productionConfig,
   test: testConfig
 }


### PR DESCRIPTION
For developing reasons (productivity mainly), it's better to use the esperanto analyzer API hosted at Heroku on development environment instead of API local hosted.