### PR TITLE
Fix analyze results doesn't appears.

### DIFF
--- a/src/Lib/API.js
+++ b/src/Lib/API.js
@@ -16,7 +16,14 @@ class API {
   static analyzeSentence(sentence) {
     const endpoint = ANALYZE_ENDPOINT.replace(':sentence', sentence)
 
-    return this.get(endpoint)
+    return this.get(endpoint).then(response => {
+      if (response.ok) {
+        return response.json().then(response => (response));
+      }
+
+      return response.json().then(error => ({ error }));
+    })
+
   }
 
   static request(path, options = {}) {

--- a/src/Lib/API.test.js
+++ b/src/Lib/API.test.js
@@ -1,16 +1,10 @@
 import API, { DEFAULT_HEADERS } from './API'
 
 describe('API', () => {
-    beforeEach(function() {
-        global.fetch = jest.fn().mockImplementation(() => {
-            return new Promise((resolve, _reject) => {
-              resolve({
-                json: function() { 
-                  return [{'word': 'Mi', 'value': 'pronoun'}]
-                }
-              })
-            })
-        }); 
+    beforeEach(() => {
+        global.fetch = jest.fn().mockImplementation(() => (
+            Promise.resolve()
+        ));
     });
 
     describe('#request', () => {
@@ -50,7 +44,7 @@ describe('API', () => {
             API.get('/endpoint', { hello: 'world', ping: 'pong'}) // dispatch the request
 
             expect(API.request.mock.calls[0][1].hello).toEqual('world')
-            expect(API.request.mock.calls[0][1].ping).toEqual('pong')            
+            expect(API.request.mock.calls[0][1].ping).toEqual('pong')
         })
     })
 
@@ -69,20 +63,28 @@ describe('API', () => {
             API.post('/post_endpoint', { hello: 'world', ping: 'pong'}) // dispatch the request
 
             expect(API.request.mock.calls[0][1].hello).toEqual('world')
-            expect(API.request.mock.calls[0][1].ping).toEqual('pong')            
+            expect(API.request.mock.calls[0][1].ping).toEqual('pong')
         })
     })
 
     describe('#analyzeSentence', () => {
+        const requestMockImplementation = jest.fn().mockImplementation(() => (
+            Promise.resolve({
+                json: () => (
+                    Promise.resolve([{'word': 'Mi', 'value': 'pronoun'}])
+                )
+            })
+        ));
+
         it("Should call `request` with `method: 'GET'", () => {
-            API.request = jest.fn() // mock the current implementation
+            API.request = requestMockImplementation // mock the current implementation
             API.analyzeSentence('Mia')
 
             expect(API.request.mock.calls[0][1].method).toEqual('GET')
         })
 
         it("Should call the proper endpoint in remote API", () => {
-            API.request = jest.fn() // mock the current implementation
+            API.request = requestMockImplementation // mock the current implementation
             API.analyzeSentence('Mia')
 
             expect(API.request.mock.calls[0][0]).toEqual('/analyze?sentence=Mia')

--- a/src/Pages/Home.jsx
+++ b/src/Pages/Home.jsx
@@ -93,7 +93,7 @@ class PageHome extends Component {
   }
 
   analyzeSentenceAPIRequest(sentence, callback=((json) => (json))) {
-    return API.analyzeSentence(sentence).then((response) => (callback(response.json())))
+    return API.analyzeSentence(sentence).then((response) => (callback(response)))
   }
 
   render() {

--- a/src/Pages/Home.test.jsx
+++ b/src/Pages/Home.test.jsx
@@ -323,7 +323,7 @@ describe('<PageHome />', () => {
       mountComponent((home, next) => {
         API.analyzeSentence = jest.fn((sentence) => {
           return new Promise((resolve, error) => {
-            process.nextTick(() => resolve({ json: () => (SAMPLE_SENTENCE_JSON_RESPONSE) }))
+            process.nextTick(() => resolve(SAMPLE_SENTENCE_JSON_RESPONSE))
           })
         })
 


### PR DESCRIPTION
SentenceAnalyzeResult component expects its result props has length attribute. Although this props was receiving a Promise from `response.json()`. As we've already know Promise doesn't have length attributes.

I've changed the API to return the body response.